### PR TITLE
Bug fix interacting with the options bar while setting panel is visible

### DIFF
--- a/CarConfigurator-UI/src/CarConfigurator/CarConfigurator.ts
+++ b/CarConfigurator-UI/src/CarConfigurator/CarConfigurator.ts
@@ -724,10 +724,10 @@ export class CarConfigurator {
         this.seatPanel.hide();
 
         if (this.settingsPanel.rootElement.classList.contains('panel-wrap-visible')) {
-            this.optionsBar.classList.add('opacity')
+            this.optionsBar.classList.add('hide')
         }
         else {
-            this.optionsBar.classList.remove('opacity')
+            this.optionsBar.classList.remove('hide')
         }
     }
 
@@ -745,10 +745,10 @@ export class CarConfigurator {
         this.seatPanel.hide();
 
         if (this.statsPanel.rootElement.classList.contains('panel-wrap-visible')) {
-            this.optionsBar.classList.add('opacity')
+            this.optionsBar.classList.add('hide')
         }
         else {
-            this.optionsBar.classList.remove('opacity')
+            this.optionsBar.classList.remove('hide')
         }
     }
 
@@ -766,10 +766,10 @@ export class CarConfigurator {
         this.seatPanel.hide();
 
         if (this.logsPanel.rootElement.classList.contains('panel-wrap-visible')) {
-            this.optionsBar.classList.add('opacity')
+            this.optionsBar.classList.add('hide')
         }
         else {
-            this.optionsBar.classList.remove('opacity')
+            this.optionsBar.classList.remove('hide')
         }
     }
 
@@ -787,10 +787,10 @@ export class CarConfigurator {
         this.seatPanel.hide();
 
         if (this.paintPanel.rootElement.classList.contains('panel-wrap-visible')) {
-            this.optionsBar.classList.add('opacity')
+            this.optionsBar.classList.add('hide')
         }
         else {
-            this.optionsBar.classList.remove('opacity')
+            this.optionsBar.classList.remove('hide')
         }
     }
 
@@ -808,10 +808,10 @@ export class CarConfigurator {
         this.seatPanel.hide();
 
         if (this.wheelPanel.rootElement.classList.contains('panel-wrap-visible')) {
-            this.optionsBar.classList.add('opacity')
+            this.optionsBar.classList.add('hide')
         }
         else {
-            this.optionsBar.classList.remove('opacity')
+            this.optionsBar.classList.remove('hide')
         }
     }
 
@@ -829,10 +829,10 @@ export class CarConfigurator {
         this.seatPanel.hide();
 
         if (this.trimPanel.rootElement.classList.contains('panel-wrap-visible')) {
-            this.optionsBar.classList.add('opacity')
+            this.optionsBar.classList.add('hide')
         }
         else {
-            this.optionsBar.classList.remove('opacity')
+            this.optionsBar.classList.remove('hide')
         }
     }
 
@@ -850,10 +850,10 @@ export class CarConfigurator {
         this.seatPanel.hide();
 
         if (this.leatherPanel.rootElement.classList.contains('panel-wrap-visible')) {
-            this.optionsBar.classList.add('opacity')
+            this.optionsBar.classList.add('hide')
         }
         else {
-            this.optionsBar.classList.remove('opacity')
+            this.optionsBar.classList.remove('hide')
         }
     }
 
@@ -871,10 +871,10 @@ export class CarConfigurator {
         this.seatPanel.toggleVisibility();
 
         if (this.seatPanel.rootElement.classList.contains('panel-wrap-visible')) {
-            this.optionsBar.classList.add('opacity')
+            this.optionsBar.classList.add('hide')
         }
         else {
-            this.optionsBar.classList.remove('opacity')
+            this.optionsBar.classList.remove('hide')
         }
     }
 

--- a/CarConfigurator-UI/src/Styles/CarConfiguratorStyles.ts
+++ b/CarConfigurator-UI/src/Styles/CarConfiguratorStyles.ts
@@ -715,6 +715,9 @@ export class CarConfiguratorStyle {
         '.opacity': {
 			'opacity': '0'
 		},
+        '.hide': {
+            'display': 'none !important'
+        },
 		'.variant-container': {
 			flexBasis: 'calc( 100% / 5 )',
 			backgroundColor: 'rgba(var(--color13), 0.2)',


### PR DESCRIPTION
When the settings panel was present the user could still interact with the options bar
this changes the options bar to hide instead of the setting the opacity to 0